### PR TITLE
Shorten custom type display in hex view

### DIFF
--- a/Cheat Engine/hexviewunit.pas
+++ b/Cheat Engine/hexviewunit.pas
@@ -1965,6 +1965,8 @@ begin
     i:=customtype.ConvertDataToInteger(@bytes[0],a);
     result:=format('%d',[i]);
   end;
+  if (not full) and (length(result)>11) then
+    result:=copy(result,1,8)+'...';       
 end;
 
 function THexView.getChar(a: ptrUint; out charlength: integer): string;


### PR DESCRIPTION
If the custom type in hex view converts to a long number string, the output in the hex view is unreadable. Added code to shorten.
![ugly_hex](https://user-images.githubusercontent.com/47719641/90451094-ae381b80-e0b0-11ea-8d12-af41bb2fa04c.png)
